### PR TITLE
forgot to pass context and arguments to command group

### DIFF
--- a/bot/general.py
+++ b/bot/general.py
@@ -64,7 +64,7 @@ class General(commands.Cog):
             await ctx.send(embed=embed)
 
     @commands.group(invoke_without_command=True)
-    async def dao(self):
+    async def dao(self, ctx, *args):
         """General DAO functionalities. Such as showing account details."""
 
     @dao.command()


### PR DESCRIPTION
throws error when calling `!help dao` since that the dao command did not have the context object and the arguments.